### PR TITLE
feat: Added hook for graph schema data

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "author": "",
   "dependencies": {
+    "graphology-types": "^0.24.0",
     "react": "18.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  graphology-types:
+    specifier: ^0.24.0
+    version: 0.24.7
   react:
     specifier: 18.2.0
     version: 18.2.0
@@ -3069,6 +3072,10 @@ packages:
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
+
+  /graphology-types@0.24.7:
+    resolution: {integrity: sha512-tdcqOOpwArNjEr0gNQKCXwaNCWnQJrog14nJNQPeemcLnXQUUGrsCWpWkVKt46zLjcS6/KGoayeJfHHyPDlvwA==}
+    dev: false
 
   /has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}

--- a/src/graphpolaris.types.ts
+++ b/src/graphpolaris.types.ts
@@ -196,3 +196,45 @@ export type SettingTypes = { [id: string]: Setting };
 
 export type SettingProps = { [K in keyof SettingTypes]: any };
 */
+
+// ------------------------------------
+// Schema
+// ------------------------------------
+
+import type {
+  Attributes as GAttributes,
+  SerializedGraph
+} from "graphology-types";
+
+export type SchemaGraphologyNode = GAttributes & SchemaNode;
+export type SchemaGraphologyEdge = GAttributes;
+
+export type SchemaGraph = SerializedGraph<
+  SchemaGraphologyNode,
+  SchemaGraphologyEdge,
+  GAttributes
+>;
+
+export type SchemaAttributeTypes =
+  | "string"
+  | "float"
+  | "int"
+  | "bool"
+  | "date"
+  | "time"
+  | "datetime"
+  | "duration";
+
+/** Attribute type, consist of a name */
+export type SchemaAttribute = {
+  name: string;
+  type: SchemaAttributeTypes;
+  dimension?: DimensionType;
+};
+
+/** Node type, consist of a name and a list of attributes */
+export type SchemaNode = {
+  name: string;
+  attributes: SchemaAttribute[];
+  type?: string;
+};

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -10,8 +10,8 @@ import { useEffect, useState } from "react";
 import { Settings, ReceiveMessage, SendMessage } from "./message";
 
 /**
- * Returns the last message received,
- * or `null` if no message has been sent  yet.
+ * Returns the data of the last message received,
+ * or `null` if no message has been sent yet.
  *
  * Component rerenders on receiving a new message.
  *
@@ -49,7 +49,7 @@ function sendMessage(message: SendMessage) {
 }
 
 /**
- * Returns the last message containing graph data
+ * Returns the data of the last message containing graph data.
  * that has been sent, or `null` if no such message has been sent.
  *
  * Component rerenders on receiving a new message.
@@ -59,7 +59,7 @@ export function useGraphData() {
 }
 
 /**
- * Returns the last message containing machine learning data
+ * Returns the data of the last message containing machine learning data
  * that has been sent, or `null` if no such message has been sent.
  *
  * Component rerenders on receiving a new message.
@@ -69,7 +69,7 @@ export function useMLData() {
 }
 
 /**
- * Returns the last message containing visualization settings
+ * Returns the data of the last message containing visualization settings
  * that has been sent, or `null` if no such message has been sent.
  *
  * Component rerenders on receiving a new message.
@@ -105,3 +105,14 @@ export function useSettings<T extends Settings>(): readonly [
  * A function to to send an update to an object.
  */
 export type UpdateFunction<T> = (changes: Partial<T>) => void;
+
+/** Returns the data of the last message containing the schema graph
+ * that has been sent, or `null` if no such message has been sent.
+ *
+ * Component rerenders on receiving a new message.
+ * 
+ * @returns A `SchemaGraph` containing the schema of the currently selected data.
+ */
+export function useSchema() {
+  return useMessage("Schema");
+}

--- a/src/message.ts
+++ b/src/message.ts
@@ -6,7 +6,11 @@
  * (Department of Information and Computing Sciences)
  */
 
-import type { GraphQueryResult, ML } from "./graphpolaris.types";
+import type {
+  GraphQueryResult,
+  ML,
+  SchemaGraph
+} from "./graphpolaris.types";
 
 interface BaseMessage {
   /** A unique string determining the type of the message. */
@@ -33,10 +37,16 @@ export interface SettingsMessage extends BaseMessage {
   data: Settings;
 }
 
+/** A message containing the schema graph. */
+export interface SchemaMessage extends BaseMessage {
+  type: "Schema";
+  data: SchemaGraph;
+}
+
 /**
- * The types of messages that an add-on can receive.
+ * The types of messages an add-on can receive.
  */
-export type ReceiveMessage = GraphMessage | MLMessage | SettingsMessage;
+export type ReceiveMessage = GraphMessage | MLMessage | SettingsMessage | SchemaMessage;
 
 /**
  * The types of messages that an add-on can send.


### PR DESCRIPTION
Note that the dependency on `graphology-types` is a real dependency, not a dev dependeny, since users of the API also need this dependecy.